### PR TITLE
add thresholds_by_sec & overlap_threshold for video_detect

### DIFF
--- a/deface/deface.py
+++ b/deface/deface.py
@@ -15,6 +15,7 @@ import imageio.v2 as iio
 import imageio.plugins.ffmpeg
 import cv2
 
+from deface import __version__
 from deface.centerface import CenterFace
 
 

--- a/deface/deface.py
+++ b/deface/deface.py
@@ -145,13 +145,10 @@ def has_overlap_with_group(det, group):
 
 
 def group_det_by_overlap(dets):
-    groups = [[]]
     ordered_dets = sorted(dets, key=lambda x: (x[0], x[1]))
+    groups = [ordered_dets[0]]
     # add to groups the det that have overlap with others
-    for det in ordered_dets:
-        if not groups[-1]:
-            groups[-1].append(det)
-            continue
+    for det in ordered_dets[1:]:
         if has_overlap_with_group(det, groups[-1]):
             groups[-1].append(det)
         else:

--- a/deface/deface.py
+++ b/deface/deface.py
@@ -138,10 +138,7 @@ def has_overlap(det, other):
 
 
 def has_overlap_with_group(det, group):
-    for other in group:
-        if has_overlap(det, other):
-            return True
-    return False
+    return any(has_overlap(det, other) for other in group)
 
 
 def group_det_by_overlap(dets):

--- a/deface/tests/test_deface.py
+++ b/deface/tests/test_deface.py
@@ -7,67 +7,171 @@ from deface.deface import (
     unionize_overlapping_dets,
     get_union_rep,
     filter_by_dets_history,
+    ThresholdTimeline
 )
 
 
 class TestDeface(unittest.TestCase):
-    def setUp(self):
-        # A detection have [x1, y1, x2, y2, score]
-        # Detect three faces, 2 overlapping
-        self.dets_1 = [
+    def test_has_overlap(self):
+        # THEN
+        self.assertEqual(has_overlap([0, 0, 10, 10, 0.5], [15, 15, 25, 25, 0.5]),
+            False, "Should be false as there is no overlap in both X and Y axis")
+        self.assertEqual(has_overlap([0, 0, 10, 10, 0.5], [0, 20, 10, 30, 0.5]),
+            False, "Should be false as the later rectangle is below the former without overlap")
+        self.assertEqual(has_overlap([0, 0, 10, 10, 0.5], [20, 0, 30, 10, 0.5]),
+            False, "Should be false as the later is on the right of the former without overlap")
+        self.assertEqual(has_overlap([0, 0, 10, 10, 0.5], [5, 5, 15, 15, 0.5]),
+            True, "Should be true as overlap with both X and Y axis")
+        self.assertEqual(has_overlap([0, 0, 10, 10, 0.5], [0, 0, 10, 10, 0.5]),
+            True, "Should be true as the same rectangle")
+
+    def test_has_overlap_with_union(self):
+        # GIVEN
+        test_det = [100, 100, 200, 200, 0.5]
+        overlap_union = [
+            [50, 50, 150, 150, 0.5],
+            [300, 300, 400, 400, 0.5]]
+
+        not_overlap_union = [
+            [100, 250, 200, 350, 0.5],
+            [300, 100, 400, 200, 0.5],
+            [250, 250, 350, 350, 0.5]]
+
+        # THEN
+        self.assertEqual(has_overlap_with_union(test_det, overlap_union),
+            True, "should overlap as there is one overlap rectangle")
+        self.assertEqual(has_overlap_with_union(test_det, not_overlap_union),
+            False, "should not overlap as the rectangles are below, right side and diagonal without overlap")
+
+    def test_unionize_overlapping_dets(self):
+        # GIVEN
+        # 2 overlapping
+        dets_1 = [
             [100, 100, 200, 200, 0.5],
             [150, 150, 190, 190, 0.25],
             [500, 500, 700, 700, 0.25],
         ]
-        # Detect three faces, none overlapping
-        self.dets_2 = [
+        # none overlapping
+        dets_2 = [
             [0, 0, 100, 100, 0.5],
             [150, 150, 190, 190, 0.25],
             [500, 500, 700, 700, 0.25],
         ]
-        # Detect three faces, all overlapping
-        self.dets_3 = [
+        # all overlapping
+        dets_3 = [
             [0, 0, 100, 100, 0.5],
             [50, 50, 90, 90, 0.25],
             [50, 50, 200, 200, 0.25],
         ]
 
-        # A history of previous detections, there is only 1 reliable detection
-        # [100, 100, 200, 200] which appears 3 times
-        self.history = [
+        # THEN
+        self.assertEqual(len(unionize_overlapping_dets(dets_1)), 2, "2 overlapping among 3, should produce 2 unions")
+        self.assertEqual(len(unionize_overlapping_dets(dets_2)), 3, "non overlapping among 3, should produce 3 unions")
+        self.assertEqual(len(unionize_overlapping_dets(dets_3)), 1, "all overlapping among 3, should produce 1 union ")
+
+    def test_get_union_rep(self):
+        # WHEN
+        # 2 unions, should produce 2 representatives
+        unions_1 = [
+            [
+                [100, 100, 200, 200, 0.5],
+                [150, 150, 190, 190, 0.25]
+            ],
+            [
+                [500, 500, 700, 700, 0.25]
+            ]
+        ]
+
+        # 3 unions, should produce 3 presentatives
+        # Since each union only have 1 member, they are their own representatives.
+        unions_2 = [
+            [
+                [100, 100, 200, 200, 0.5]
+            ],
+            [
+                [250, 250, 290, 290, 0.25]
+            ],
+            [
+                [500, 500, 700, 700, 0.25]
+            ]
+        ]
+
+        # 1 union, should produce only 1 representative
+        unions_3 = [
+            [
+                [100, 100, 200, 200, 0.5],
+                [150, 150, 190, 190, 0.25],
+                [500, 500, 700, 700, 0.25]
+            ]
+        ]
+
+
+        reps_1 = get_union_rep(unions_1)
+        reps_2 = get_union_rep(unions_2)
+        reps_3 = get_union_rep(unions_3)
+
+        # THEN
+        self.assertTrue(len(reps_1) == 2, "2 unions, should produce 2 representatives")
+        self.assertTrue((reps_1[0] == np.asarray([102, 102, 200, 200, 0.5], dtype=np.float32)).all(),
+            "incorrect representative calculation for the first union")
+
+        self.assertTrue(len(reps_2) == 3, "3 unions, should produce 3 presentatives")
+        self.assertTrue(
+            (
+                reps_2
+                == np.asarray(
+                    [
+                        [100, 100, 200, 200, 0.5],
+                        [250, 250, 290, 290, 0.25],
+                        [500, 500, 700, 700, 0.25],
+                    ],
+                    dtype=np.float32,
+                )
+            ).all(),
+            "the union members should be their own representatives",
+        )
+
+        self.assertTrue(len(reps_3) == 1, "1 union, should produce only 1 representative")
+        self.assertTrue((reps_3 == np.asarray([[399, 399, 599, 599, 0.5]], dtype=np.float32)).all(),
+            "incorrect representative calculation for the only union",
+        )
+
+    def test_filter_by_dets_history(self):
+        # GIVEN
+        # new detection that also appears 3 times before
+        new_dets_1 = [[100, 105, 200, 205, 0.5]]
+        # new detection that  appears 2 times before
+        new_dets_2 = [[10, 10, 20, 20, 0.5]]
+        # new detection that never appears before
+        new_dets_3 = [[1000, 1000, 2000, 2000, 0.5]]
+
+
+        # A history of previous detections,
+        history = [
             [
                 [
                     [10, 10, 20, 20, 0.2],
                     [5, 5, 25, 25, 0.2],
                 ],
                 [
-                    [100, 100, 200, 200, 0.2],
+                    [100, 100, 200, 200, 0.2], # reliable
                     [75, 75, 125, 125, 0.2],
                 ],
             ],
             [
                 [
-                    [300, 300, 400, 400, 0.2],
-                    [500, 500, 625, 625, 0.2],
-                ],
-                [
-                    [105, 105, 205, 205, 0.2],
-                    [65, 65, 120, 120, 0.2],
+                    [105, 105, 205, 205, 0.2], # reliable
                 ],
             ],
             [
                 [
                     [210, 210, 220, 220, 0.2],
-                ],
-                [
-                    [110, 110, 210, 210, 0.2],
+                    [110, 110, 210, 210, 0.2], # reliable
                     [85, 85, 125, 125, 0.2],
                 ],
             ],
             [
-                [
-                    [310, 310, 320, 320, 0.2],
-                ],
+                []
             ],
             [
                 [
@@ -76,116 +180,41 @@ class TestDeface(unittest.TestCase):
             ],
         ]
 
-    def test_has_overlap(self):
-        # WHEN
-        is_overlapped_1_1 = has_overlap(self.dets_1[0], self.dets_1[1])
-        is_overlapped_1_2 = has_overlap(self.dets_1[0], self.dets_1[2])
-        is_overlapped_1_3 = has_overlap(self.dets_1[1], self.dets_1[2])
-
-        is_overlapped_2_1 = has_overlap(self.dets_2[0], self.dets_2[1])
-        is_overlapped_2_2 = has_overlap(self.dets_2[0], self.dets_2[2])
-        is_overlapped_2_3 = has_overlap(self.dets_2[1], self.dets_2[2])
-
-        is_overlapped_3_1 = has_overlap(self.dets_3[0], self.dets_3[1])
-        is_overlapped_3_2 = has_overlap(self.dets_3[0], self.dets_3[2])
-        is_overlapped_3_3 = has_overlap(self.dets_3[1], self.dets_3[2])
-
         # THEN
-        self.assertEqual(is_overlapped_1_1, True, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_1_2, False, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_1_3, False, "incorrect overlap assertion")
+        self.assertEqual(
+            len(filter_by_dets_history(new_dets_1, history.copy(), 3)[0]), 1,
+            "there should be one reliable detection as a result of the consistency in history"
+        )
+        self.assertEqual(
+            len(filter_by_dets_history(new_dets_2, history.copy(), 3)[0]), 0,
+            "there should be no reliable detection due to high consistency_threshold"
+        )
+        self.assertEqual(
+            len(filter_by_dets_history(new_dets_3, history.copy(), 0)[0]), 1,
+            "the new detection is never seen before but there is no consistency_threshold so it becomes reliable "
+        )
+        self.assertEqual(
+            len(filter_by_dets_history(new_dets_3, history.copy(), 1)[0]), 0,
+            "the same new detection that is never seen before now is reject due to the consistency_threshold is set to 1 "
+        )
 
-        self.assertEqual(is_overlapped_2_1, False, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_2_2, False, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_2_3, False, "incorrect overlap assertion")
-
-        self.assertEqual(is_overlapped_3_1, True, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_3_2, True, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_3_3, True, "incorrect overlap assertion")
-
-    def test_has_overlap_with_union(self):
+    def test_threshold_timeline(self):
         # GIVEN
-        test_dets = [400, 400, 600, 600, 0.5]
-
-        # WHEN
-        is_overlapped_1 = has_overlap_with_union(test_dets, self.dets_1)
-        is_overlapped_2 = has_overlap_with_union(test_dets, self.dets_2)
-        is_overlapped_3 = has_overlap_with_union(test_dets, self.dets_3)
+        thresholds_timeline_empty = ThresholdTimeline({}, 0.5, 1)
+        thresholds_timeline_normal = ThresholdTimeline({1: 0.2, 5: 0.6}, 0.5, 2)
 
         # THEN
-        self.assertEqual(is_overlapped_1, True, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_2, True, "incorrect overlap assertion")
-        self.assertEqual(is_overlapped_3, False, "incorrect overlap assertion")
+        self.assertTrue(thresholds_timeline_empty.thresholds == {0: 0.5},
+            "even an empty timeline should have at threshold starting at frame 0")
+        self.assertTrue(thresholds_timeline_normal.thresholds == {0: 0.5, 2: 0.2, 10: 0.6},
+            "normal threshold timeline should be reflected")
+        self.assertTrue(thresholds_timeline_normal.fps == 2,
+            "fps must match")
+        self.assertTrue(thresholds_timeline_normal.default_threshold == 0.5,
+            "default threshold must match")
 
-    def test_unionize_overlapping_dets(self):
-        # WHEN
-        groups_1 = unionize_overlapping_dets(self.dets_1)
-        groups_2 = unionize_overlapping_dets(self.dets_2)
-        groups_3 = unionize_overlapping_dets(self.dets_3)
+        self.assertTrue(thresholds_timeline_normal.threshold_for_frame(1) == 0.5, "2 > frame 1 > 0 so it should have a threshold of 0.5")
+        self.assertTrue(thresholds_timeline_normal.threshold_for_frame(2) == 0.2, "frame 2 == 2, should have a threshold of 0.2")
+        self.assertTrue(thresholds_timeline_normal.threshold_for_frame(100) == 0.6, "frame 100 > 10, should have a threshold of 0.6")
 
-        # THEN
-        self.assertEqual(len(groups_1), 2, "incorrect number of groups")
-        self.assertEqual(len(groups_2), 3, "incorrect number of groups")
-        self.assertEqual(len(groups_3), 1, "incorrect number of groups")
 
-    def test_get_union_rep(self):
-        # WHEN
-        groups_1 = unionize_overlapping_dets(self.dets_1)
-        groups_2 = unionize_overlapping_dets(self.dets_2)
-        groups_3 = unionize_overlapping_dets(self.dets_3)
-
-        centeroid_1 = get_union_rep(groups_1)
-        centeroid_2 = get_union_rep(groups_2)
-        centeroid_3 = get_union_rep(groups_3)
-
-        # THEN
-        self.assertTrue(
-            (
-                centeroid_1
-                == np.asarray(
-                    [
-                        [102, 102, 200, 200, 0.5],
-                        [500, 500, 700, 700, 0.25],
-                    ],
-                    dtype=np.float32,
-                )
-            ).all(),
-            "incorrect centeroid calculation",
-        )
-        self.assertTrue(
-            (
-                centeroid_2
-                == np.asarray(
-                    [
-                        [0, 0, 100, 100, 0.5],
-                        [150, 150, 190, 190, 0.25],
-                        [500, 500, 700, 700, 0.25],
-                    ],
-                    dtype=np.float32,
-                )
-            ).all(),
-            "incorrect centeroid calculation",
-        )
-        self.assertTrue(
-            (
-                centeroid_3 == np.asarray([[25, 25, 175, 175, 0.5]], dtype=np.float32)
-            ).all(),
-            "incorrect centeroid calculation",
-        )
-
-    def test_filter_by_dets_history(self):
-        # WHEN
-        new_dets_1, _ = filter_by_dets_history(self.dets_1, self.history.copy(), 3)
-        new_dets_2, _ = filter_by_dets_history(self.dets_2, self.history.copy(), 5)
-        new_dets_3, _ = filter_by_dets_history(self.dets_3, self.history.copy(), 0)
-
-        # THEN
-        self.assertEqual(
-            len(new_dets_1), 1, "incorrect number of detection after filtering"
-        )
-        self.assertEqual(
-            len(new_dets_2), 0, "incorrect number of detection after filtering"
-        )
-        self.assertEqual(
-            len(new_dets_3), 1, "incorrect number of detection after filtering"
-        )

--- a/deface/tests/test_deface.py
+++ b/deface/tests/test_deface.py
@@ -139,11 +139,11 @@ class TestDeface(unittest.TestCase):
     def test_filter_by_dets_history(self):
         # GIVEN
         # new detection that also appears 3 times before
-        new_dets_1 = [[100, 105, 200, 205, 0.5]]
+        new_dets_1 = np.array([[100, 105, 200, 205, 0.5]], dtype=np.float32)
         # new detection that  appears 2 times before
-        new_dets_2 = [[10, 10, 20, 20, 0.5]]
+        new_dets_2 = np.array([[10, 10, 20, 20, 0.5]], dtype=np.float32)
         # new detection that never appears before
-        new_dets_3 = [[1000, 1000, 2000, 2000, 0.5]]
+        new_dets_3 = np.array([[1000, 1000, 2000, 2000, 0.5]], dtype=np.float32)
 
 
         # A history of previous detections,

--- a/deface/tests/test_deface.py
+++ b/deface/tests/test_deface.py
@@ -3,10 +3,10 @@ import numpy as np
 
 from deface.deface import (
     has_overlap,
-    has_overlap_with_group,
-    group_det_by_overlap,
-    get_group_centeroid,
-    filter_dets_by_cache,
+    has_overlap_with_union,
+    unionize_overlapping_dets,
+    get_union_rep,
+    filter_by_dets_history,
 )
 
 
@@ -32,9 +32,9 @@ class TestDeface(unittest.TestCase):
             [50, 50, 200, 200, 0.25],
         ]
 
-        # A cache of previous detections, there is only 1 reliable detection
+        # A history of previous detections, there is only 1 reliable detection
         # [100, 100, 200, 200] which appears 3 times
-        self.cache = [
+        self.history = [
             [
                 [
                     [10, 10, 20, 20, 0.2],
@@ -103,40 +103,40 @@ class TestDeface(unittest.TestCase):
         self.assertEqual(is_overlapped_3_2, True, "incorrect overlap assertion")
         self.assertEqual(is_overlapped_3_3, True, "incorrect overlap assertion")
 
-    def test_has_overlap_with_group(self):
+    def test_has_overlap_with_union(self):
         # GIVEN
         test_dets = [400, 400, 600, 600, 0.5]
 
         # WHEN
-        is_overlapped_1 = has_overlap_with_group(test_dets, self.dets_1)
-        is_overlapped_2 = has_overlap_with_group(test_dets, self.dets_2)
-        is_overlapped_3 = has_overlap_with_group(test_dets, self.dets_3)
+        is_overlapped_1 = has_overlap_with_union(test_dets, self.dets_1)
+        is_overlapped_2 = has_overlap_with_union(test_dets, self.dets_2)
+        is_overlapped_3 = has_overlap_with_union(test_dets, self.dets_3)
 
         # THEN
         self.assertEqual(is_overlapped_1, True, "incorrect overlap assertion")
         self.assertEqual(is_overlapped_2, True, "incorrect overlap assertion")
         self.assertEqual(is_overlapped_3, False, "incorrect overlap assertion")
 
-    def test_group_det_by_overlap(self):
+    def test_unionize_overlapping_dets(self):
         # WHEN
-        groups_1 = group_det_by_overlap(self.dets_1)
-        groups_2 = group_det_by_overlap(self.dets_2)
-        groups_3 = group_det_by_overlap(self.dets_3)
+        groups_1 = unionize_overlapping_dets(self.dets_1)
+        groups_2 = unionize_overlapping_dets(self.dets_2)
+        groups_3 = unionize_overlapping_dets(self.dets_3)
 
         # THEN
         self.assertEqual(len(groups_1), 2, "incorrect number of groups")
         self.assertEqual(len(groups_2), 3, "incorrect number of groups")
         self.assertEqual(len(groups_3), 1, "incorrect number of groups")
 
-    def test_get_group_centeroid(self):
+    def test_get_union_rep(self):
         # WHEN
-        groups_1 = group_det_by_overlap(self.dets_1)
-        groups_2 = group_det_by_overlap(self.dets_2)
-        groups_3 = group_det_by_overlap(self.dets_3)
+        groups_1 = unionize_overlapping_dets(self.dets_1)
+        groups_2 = unionize_overlapping_dets(self.dets_2)
+        groups_3 = unionize_overlapping_dets(self.dets_3)
 
-        centeroid_1 = get_group_centeroid(groups_1)
-        centeroid_2 = get_group_centeroid(groups_2)
-        centeroid_3 = get_group_centeroid(groups_3)
+        centeroid_1 = get_union_rep(groups_1)
+        centeroid_2 = get_union_rep(groups_2)
+        centeroid_3 = get_union_rep(groups_3)
 
         # THEN
         self.assertTrue(
@@ -173,11 +173,11 @@ class TestDeface(unittest.TestCase):
             "incorrect centeroid calculation",
         )
 
-    def test_filter_dets_by_cache(self):
+    def test_filter_by_dets_history(self):
         # WHEN
-        new_dets_1, _ = filter_dets_by_cache(self.dets_1, self.cache.copy(), 3)
-        new_dets_2, _ = filter_dets_by_cache(self.dets_2, self.cache.copy(), 5)
-        new_dets_3, _ = filter_dets_by_cache(self.dets_3, self.cache.copy(), 0)
+        new_dets_1, _ = filter_by_dets_history(self.dets_1, self.history.copy(), 3)
+        new_dets_2, _ = filter_by_dets_history(self.dets_2, self.history.copy(), 5)
+        new_dets_3, _ = filter_by_dets_history(self.dets_3, self.history.copy(), 0)
 
         # THEN
         self.assertEqual(
@@ -187,5 +187,5 @@ class TestDeface(unittest.TestCase):
             len(new_dets_2), 0, "incorrect number of detection after filtering"
         )
         self.assertEqual(
-            len(new_dets_3), 1, "incorrect number of detection after filteringn"
+            len(new_dets_3), 1, "incorrect number of detection after filtering"
         )

--- a/deface/tests/test_deface.py
+++ b/deface/tests/test_deface.py
@@ -144,7 +144,7 @@ class TestDeface(unittest.TestCase):
                 centeroid_1
                 == np.asarray(
                     [
-                        [100, 100, 210, 210, 0.5],
+                        [102, 102, 200, 200, 0.5],
                         [500, 500, 700, 700, 0.25],
                     ],
                     dtype=np.float32,
@@ -168,7 +168,7 @@ class TestDeface(unittest.TestCase):
         )
         self.assertTrue(
             (
-                centeroid_3 == np.asarray([[0, 0, 200, 200, 0.5]], dtype=np.float32)
+                centeroid_3 == np.asarray([[25, 25, 175, 175, 0.5]], dtype=np.float32)
             ).all(),
             "incorrect centeroid calculation",
         )

--- a/deface/tests/test_deface.py
+++ b/deface/tests/test_deface.py
@@ -1,0 +1,191 @@
+import unittest
+import numpy as np
+
+from deface.deface import (
+    has_overlap,
+    has_overlap_with_group,
+    group_det_by_overlap,
+    get_group_centeroid,
+    filter_dets_by_cache,
+)
+
+
+class TestDeface(unittest.TestCase):
+    def setUp(self):
+        # A detection have [x1, y1, x2, y2, score]
+        # Detect three faces, 2 overlapping
+        self.dets_1 = [
+            [100, 100, 200, 200, 0.5],
+            [150, 150, 190, 190, 0.25],
+            [500, 500, 700, 700, 0.25],
+        ]
+        # Detect three faces, none overlapping
+        self.dets_2 = [
+            [0, 0, 100, 100, 0.5],
+            [150, 150, 190, 190, 0.25],
+            [500, 500, 700, 700, 0.25],
+        ]
+        # Detect three faces, all overlapping
+        self.dets_3 = [
+            [0, 0, 100, 100, 0.5],
+            [50, 50, 90, 90, 0.25],
+            [50, 50, 200, 200, 0.25],
+        ]
+
+        # A cache of previous detections, there is only 1 reliable detection
+        # [100, 100, 200, 200] which appears 3 times
+        self.cache_1 = [
+            [
+                [
+                    [10, 10, 20, 20, 0.2],
+                    [5, 5, 25, 25, 0.2],
+                ],
+                [
+                    [100, 100, 200, 200, 0.2],
+                    [75, 75, 125, 125, 0.2],
+                ],
+            ],
+            [
+                [
+                    [300, 300, 400, 400, 0.2],
+                    [500, 500, 625, 625, 0.2],
+                ],
+                [
+                    [105, 105, 205, 205, 0.2],
+                    [65, 65, 120, 120, 0.2],
+                ],
+            ],
+            [
+                [
+                    [210, 210, 220, 220, 0.2],
+                ],
+                [
+                    [110, 110, 210, 210, 0.2],
+                    [85, 85, 125, 125, 0.2],
+                ],
+            ],
+            [
+                [
+                    [310, 310, 320, 320, 0.2],
+                ],
+            ],
+            [
+                [
+                    [10, 10, 20, 20, 0.2],
+                ],
+            ],
+        ]
+
+    def test_has_overlap(self):
+        # WHEN
+        is_overlapped_1_1 = has_overlap(self.dets_1[0], self.dets_1[1])
+        is_overlapped_1_2 = has_overlap(self.dets_1[0], self.dets_1[2])
+        is_overlapped_1_3 = has_overlap(self.dets_1[1], self.dets_1[2])
+
+        is_overlapped_2_1 = has_overlap(self.dets_2[0], self.dets_2[1])
+        is_overlapped_2_2 = has_overlap(self.dets_2[0], self.dets_2[2])
+        is_overlapped_2_3 = has_overlap(self.dets_2[1], self.dets_2[2])
+
+        is_overlapped_3_1 = has_overlap(self.dets_3[0], self.dets_3[1])
+        is_overlapped_3_2 = has_overlap(self.dets_3[0], self.dets_3[2])
+        is_overlapped_3_3 = has_overlap(self.dets_3[1], self.dets_3[2])
+
+        # THEN
+        self.assertEqual(is_overlapped_1_1, True, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_1_2, False, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_1_3, False, "incorrect overlap assertion")
+
+        self.assertEqual(is_overlapped_2_1, False, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_2_2, False, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_2_3, False, "incorrect overlap assertion")
+
+        self.assertEqual(is_overlapped_3_1, True, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_3_2, True, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_3_3, True, "incorrect overlap assertion")
+
+    def test_has_overlap_with_group(self):
+        # GIVEN
+        test_dets = [400, 400, 600, 600, 0.5]
+
+        # WHEN
+        is_overlapped_1 = has_overlap_with_group(test_dets, self.dets_1)
+        is_overlapped_2 = has_overlap_with_group(test_dets, self.dets_2)
+        is_overlapped_3 = has_overlap_with_group(test_dets, self.dets_3)
+
+        # THEN
+        self.assertEqual(is_overlapped_1, True, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_2, True, "incorrect overlap assertion")
+        self.assertEqual(is_overlapped_3, False, "incorrect overlap assertion")
+
+    def test_group_det_by_overlap(self):
+        # WHEN
+        groups_1 = group_det_by_overlap(self.dets_1)
+        groups_2 = group_det_by_overlap(self.dets_2)
+        groups_3 = group_det_by_overlap(self.dets_3)
+
+        # THEN
+        self.assertEqual(len(groups_1), 2, "incorrect number of groups")
+        self.assertEqual(len(groups_2), 3, "incorrect number of groups")
+        self.assertEqual(len(groups_3), 1, "incorrect number of groups")
+
+    def test_get_group_centeroid(self):
+        # WHEN
+        groups_1 = group_det_by_overlap(self.dets_1)
+        groups_2 = group_det_by_overlap(self.dets_2)
+        groups_3 = group_det_by_overlap(self.dets_3)
+
+        centeroid_1 = get_group_centeroid(groups_1)
+        centeroid_2 = get_group_centeroid(groups_2)
+        centeroid_3 = get_group_centeroid(groups_3)
+
+        # THEN
+        self.assertTrue(
+            (
+                centeroid_1
+                == np.asarray(
+                    [
+                        [100, 100, 210, 210, 0.5],
+                        [500, 500, 700, 700, 0.25],
+                    ],
+                    dtype=np.float32,
+                )
+            ).all(),
+            "incorrect centeroid calculation",
+        )
+        self.assertTrue(
+            (
+                centeroid_2
+                == np.asarray(
+                    [
+                        [0, 0, 100, 100, 0.5],
+                        [150, 150, 190, 190, 0.25],
+                        [500, 500, 700, 700, 0.25],
+                    ],
+                    dtype=np.float32,
+                )
+            ).all(),
+            "incorrect centeroid calculation",
+        )
+        self.assertTrue(
+            (
+                centeroid_3 == np.asarray([[0, 0, 200, 200, 0.5]], dtype=np.float32)
+            ).all(),
+            "incorrect centeroid calculation",
+        )
+
+    def test_filter_dets_by_cache(self):
+        # WHEN
+        new_dets_1, _ = filter_dets_by_cache(self.dets_1, self.cache_1, 3)
+        new_dets_2, _ = filter_dets_by_cache(self.dets_2, self.cache_1, 5)
+        new_dets_3, _ = filter_dets_by_cache(self.dets_3, self.cache_1, 0)
+
+        # THEN
+        self.assertEqual(
+            len(new_dets_1), 1, "incorrect number of detection after filtering"
+        )
+        self.assertEqual(
+            len(new_dets_2), 0, "incorrect number of detection after filtering"
+        )
+        self.assertEqual(
+            len(new_dets_3), 1, "incorrect number of detection after filteringn"
+        )

--- a/deface/tests/test_deface.py
+++ b/deface/tests/test_deface.py
@@ -34,7 +34,7 @@ class TestDeface(unittest.TestCase):
 
         # A cache of previous detections, there is only 1 reliable detection
         # [100, 100, 200, 200] which appears 3 times
-        self.cache_1 = [
+        self.cache = [
             [
                 [
                     [10, 10, 20, 20, 0.2],
@@ -175,9 +175,9 @@ class TestDeface(unittest.TestCase):
 
     def test_filter_dets_by_cache(self):
         # WHEN
-        new_dets_1, _ = filter_dets_by_cache(self.dets_1, self.cache_1, 3)
-        new_dets_2, _ = filter_dets_by_cache(self.dets_2, self.cache_1, 5)
-        new_dets_3, _ = filter_dets_by_cache(self.dets_3, self.cache_1, 0)
+        new_dets_1, _ = filter_dets_by_cache(self.dets_1, self.cache.copy(), 3)
+        new_dets_2, _ = filter_dets_by_cache(self.dets_2, self.cache.copy(), 5)
+        new_dets_3, _ = filter_dets_by_cache(self.dets_3, self.cache.copy(), 0)
 
         # THEN
         self.assertEqual(


### PR DESCRIPTION
#### What's this PR do?
This PR add customize `video_detect` function based on deface module.
It adds:
- thresholds_by_sec param: the threshold to identify a detected object as a face (and apply blurring). Now this param accept a dictionary of {time (second): float, threshold: float}
- Frame history of 5 previous detections.
- A consistency_threshold: the necessary number of frame in history that has overlap with new detection to consider a new detection is reliable.
- A grouping algorithm: to group all detected faces that have overlapping area into one detection (using weighted average centroids based on area and max width, height and score). This to avoid the case where detection are duplicated on the same face multiple time.

#### How should this be manually tested?
1. Unittest: almost all modified/ added function have their unittest. Run `python -m pytest tests/test_deface.py` to see if they are all passed

2. Installation & command line test: 
Install from this branch & run cli command to verify the new changes
```
pip install 'git+https://github.com/bespoke-inc/deface.git@phan/impv_video_detect'
OR
pip install -e .

deface examples/trimmed.mp4 --thresh 0.05 --thresholds_by_sec "{1: 0.99}"  --consistency_threshold 2
(after 1 sec, there should be no blurring) 
```

3. Calling in python code :
```
from deface.deface import video_detect
from deface.centerface import CenterFace
from pathlib import Path
import time

deface_path = "examples/trimmed.mp4"
threshold = 0.2

global_threshold = 0.05
local_thresholds = {1: 0.9}

video_detect(ipath=deface_path,
             opath="examples/trimmed_defaced.mp4", 
             default_threshold=global_threshold,
             keep_audio=True,
             centerface=CenterFace(in_shape=(640,480), backend="onnxrt"),
             replacewith='blur',
             mask_scale=1,
             ellipse=True,
             enable_preview=False,
             cam=False,
             nested=False,
             draw_scores=False,
             ffmpeg_config={"codec": "libx264"},
             thresholds_by_sec=local_thresholds,
             consistency_threshold=2
            )
```

#### Any background context you want to provide?
This PR is opened after discussion with Cyril [here](https://github.com/bespoke-inc/beproduced/pull/19)

#### Extra related tickets?
None

#### Open questions
None
